### PR TITLE
Use orange brand color for primary buttons

### DIFF
--- a/public/assets/front/css/style.css
+++ b/public/assets/front/css/style.css
@@ -73,7 +73,7 @@
 }
 
 .btn.btn-primary {
-    background: #d70000 !important;
+    background: #FF6600 !important;
     color: var(--bs-white) !important;
     font-family: 'Kanit', sans-serif;
     border: none;
@@ -82,7 +82,7 @@
 }
 
 .btn.btn-primary:hover {
-    background: #a30000 !important;
+    background: #CC5200 !important;
     color: var(--bs-light) !important;
 }
 


### PR DESCRIPTION
## Summary
- switch primary button background to brand orange
- darken hover state to deeper orange for contrast

## Testing
- `npm test` *(fails: Missing script "test")*
- `composer install` *(fails: nette/schema v1.3.0 requires php 8.1 - 8.3)*

------
https://chatgpt.com/codex/tasks/task_e_689e150c27c08324857d9bd0f09b8c4d