### PR TITLE
refactor: move trophy colors to css classes

### DIFF
--- a/public/assets/front/css/custom.css
+++ b/public/assets/front/css/custom.css
@@ -143,3 +143,7 @@ clear: both;
     box-shadow: inset 2px 2px 4px 0 #ccc;
     color: #666;
 }
+.trophy-gold { color: #FFD700; }
+.trophy-silver { color: #C0C0C0; }
+.trophy-bronze { color: #CD7F32; }
+

--- a/resources/views/livewire/admin/components/match-management-table.blade.php
+++ b/resources/views/livewire/admin/components/match-management-table.blade.php
@@ -73,13 +73,13 @@
                     <td> {{ $match->league?->name }} </td>
                     <td>
                         @if ($match->result?->team_match_result === 'home')
-                            <span style="color:goldenrod"><i class="fa-solid fa-trophy"></i></span>
+                            <i class="fa-solid fa-trophy trophy-gold"></i>
                         @endif
                         {{ $match->homeTeam?->name }}
                     </td>
                     <td>
                         @if ($match->result?->team_match_result === 'away')
-                            <span style="color:goldenrod"><i class="fa-solid fa-trophy"></i></span>
+                            <i class="fa-solid fa-trophy trophy-gold"></i>
                         @endif
                         {{ $match->awayTeam?->name }}
                     </td>

--- a/resources/views/livewire/index.blade.php
+++ b/resources/views/livewire/index.blade.php
@@ -80,11 +80,11 @@
                                 <tr>
                                     <th>
                                         @if($i+1 == 1)
-                                            <i class="fa-solid fa-trophy" style="color: gold;"></i>
+                                            <i class="fa-solid fa-trophy trophy-gold"></i>
                                         @elseif($i+1 == 2)
-                                            <i class="fa-solid fa-trophy" style="color: silver;"></i>
+                                            <i class="fa-solid fa-trophy trophy-silver"></i>
                                         @elseif($i+1 == 3)
-                                            <i class="fa-solid fa-trophy" style="color: #cd7f32;"></i>
+                                            <i class="fa-solid fa-trophy trophy-bronze"></i>
                                         @else
                                             <span class="d-inline-flex justify-content-center align-items-center me-1"
                                                   style="width:28px;height:28px;border-radius:50%;background:#f1f1f1;font-weight:600;">
@@ -111,11 +111,11 @@
                                         @if($i+1 <= 3)
                                             {{-- กรณีไม่มีข้อมูล แต่อยากให้หัวตารางสวยสม่ำเสมอ --}}
                                             @if($i+1 == 1)
-                                                <i class="fa-solid fa-trophy" style="color: gold;"></i> {{ $i+1 }}
+                                                  <i class="fa-solid fa-trophy trophy-gold"></i> {{ $i+1 }}
                                             @elseif($i+1 == 2)
-                                                <i class="fa-solid fa-trophy" style="color: silver;"></i> {{ $i+1 }}
+                                                  <i class="fa-solid fa-trophy trophy-silver"></i> {{ $i+1 }}
                                             @else
-                                                <i class="fa-solid fa-trophy" style="color: #cd7f32;"></i> {{ $i+1 }}
+                                                  <i class="fa-solid fa-trophy trophy-bronze"></i> {{ $i+1 }}
                                             @endif
                                         @else
                                             <span class="d-inline-flex justify-content-center align-items-center me-1"
@@ -154,11 +154,11 @@
                                 <tr>
                                     <th>
                                         @if($i+1 == 1)
-                                            <i class="fa-solid fa-trophy" style="color: gold;"></i>
+                                            <i class="fa-solid fa-trophy trophy-gold"></i>
                                         @elseif($i+1 == 2)
-                                            <i class="fa-solid fa-trophy" style="color: silver;"></i>
+                                            <i class="fa-solid fa-trophy trophy-silver"></i>
                                         @elseif($i+1 == 3)
-                                            <i class="fa-solid fa-trophy" style="color: #cd7f32;"></i>
+                                            <i class="fa-solid fa-trophy trophy-bronze"></i>
                                         @else
                                             <span class="d-inline-flex justify-content-center align-items-center me-1"
                                                   style="width:28px;height:28px;border-radius:50%;background:#f1f1f1;font-weight:600;">
@@ -184,11 +184,11 @@
                                     <th>
                                         @if($i+1 <= 3)
                                             @if($i+1 == 1)
-                                                <i class="fa-solid fa-trophy" style="color: gold;"></i> {{ $i+1 }}
+                                                  <i class="fa-solid fa-trophy trophy-gold"></i> {{ $i+1 }}
                                             @elseif($i+1 == 2)
-                                                <i class="fa-solid fa-trophy" style="color: silver;"></i> {{ $i+1 }}
+                                                  <i class="fa-solid fa-trophy trophy-silver"></i> {{ $i+1 }}
                                             @else
-                                                <i class="fa-solid fa-trophy" style="color: #cd7f32;"></i> {{ $i+1 }}
+                                                  <i class="fa-solid fa-trophy trophy-bronze"></i> {{ $i+1 }}
                                             @endif
                                         @else
                                             <span class="d-inline-flex justify-content-center align-items-center me-1"

--- a/resources/views/livewire/prediction-rank.blade.php
+++ b/resources/views/livewire/prediction-rank.blade.php
@@ -59,7 +59,7 @@
                                 @php $authId = auth()->id(); @endphp
 
                                 @if ($item->id === $authId)
-                                    <span style="color:goldenrod"><i class="fas fa-solid fa-trophy"></i></span>
+                                      <i class="fas fa-solid fa-trophy trophy-gold"></i>
 
                                 @elseif (!empty($item->targetViewPrediction) && count($item->targetViewPrediction) > 0)
                                     <button type="button" class="btn btn-primary btn-sm"
@@ -124,7 +124,7 @@
                             <td>
                                 <a class="text-dark">{{ $item->nick_name }}</a>
                                 @if ($item->id === auth()->id())
-                                    <span style="color:goldenrod"><i class="fas fa-solid fa-trophy"></i></span>
+                                      <i class="fas fa-solid fa-trophy trophy-gold"></i>
                                 @endif
                             </td>
                             <td class="d-none d-sm-block mt-1">


### PR DESCRIPTION
## Summary
- centralize trophy color styling into reusable CSS classes
- replace inline trophy color styles in leaderboards and match tables

## Testing
- `php artisan test` *(fails: Failed opening required '/workspace/guball-bo/vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_689e158e9640832490353115e131e24e