### PR TITLE
Refactor admin CSS gradient and table styles

### DIFF
--- a/public/assets/admin/css/custom.css
+++ b/public/assets/admin/css/custom.css
@@ -16,27 +16,29 @@ a:link, a:visited, a:hover, a:active {
     border-bottom: 1px solid #dee2e600 !important;
 }
 .bg-dark {
-    background: linear-gradient(to bottom, #061435, #000c27, #03001a);
+    background: linear-gradient(to bottom, #000000, #b1b1b1, #ff5002);
 }
 @media only screen and (max-width: 600px) {
     table {
         thead tr {
             height: 60px;
-            background: #000102;
+            background: #000000;
+            border-bottom: 2px solid #ff5002;
             font-size: 12px;
-            color: #e9ecef;
+            color: #f8f9fa;
         }
     }
 }
 table {
     thead tr {
         height: 60px;
-        background: #000102;
+        background: #000000;
+        border-bottom: 2px solid #ff5002;
         font-size: 18px;
-        color: #e9ecef;
+        color: #f8f9fa;
     }
 }
 .copyright {
     border-top: 1px solid rgba(255, 255, 255, 0.08);
-    background: linear-gradient(to bottom, #061435, #000c27, #03001a);
+    background: linear-gradient(to bottom, #000000, #b1b1b1, #ff5002);
 }


### PR DESCRIPTION
## Summary
- Replace dark blue gradient backgrounds with a black-silver palette accented by front-end orange
- Improve admin table headers with black backgrounds, orange borders, and brighter text for contrast

## Testing
- `npm test` *(fails: Missing script "test")*
- `composer install` *(fails: nette/schema requires php 8.1 - 8.3, current php 8.4.11)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689e158df64483248ffaded314f976ef